### PR TITLE
ci: release after merge to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,20 +4,73 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
-  build:
+  check-changes:
+    name: Check changes since last commit
+    runs-on: ubuntu-24.04
+    outputs:
+      image: ${{ steps.changes.outputs.image }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          filters: |
+            image:
+              - '.github/workflows/ci.yml'
+              - 'fedora-bootc'
+              - 'almalinux-bootc*'
+              - 'Containerfile'
+
+  build-push:
     name: Build base image
+    env:
+      IMAGE_NAME: almalinux
+      REGISTRY: ghcr.io/${{ github.repository_owner }}/bootc
+    needs: check-changes
+    if: needs.check-changes.outputs.image == 'true'
+    outputs:
+      digest: 
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           submodules: 'true'
-      - name: Build Image
-        uses: redhat-actions/buildah-build@v2
+
+      - name: Set image tags
+        id: tags
+        run: |
+          #!/bin/bash
+
+          set -xeo pipefail
+          releasever=$(yq '.releasever' 'almalinux-bootc.yaml')
+          tags=$releasever
+          suffixes="${{ github.sha }} $(date +%Y%m%d)"
+
+          if [[ "${{ github.event_name }}" != "pull_request" ]]
+          then
+            suffixes+=" ${{ github.ref_name }}"
+          fi
+
+          for suffix in $suffixes
+          do 
+            tags+=" ${releasever}-${suffix}"
+          done
+          echo "tags=$tags" >> "$GITHUB_OUTPUT"
+
+      - name: Build image
+        id: build
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
-          image: localhost/almalinux-bootc
+          image: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.tags.outputs.tags }}
           containerfiles: |
             Containerfile
           oci: 'true'
@@ -25,3 +78,29 @@ jobs:
             --security-opt=label=disable
             --cap-add=all
             --device /dev/fuse
+
+      - name: Push image to ghcr.io
+        id: push
+        if: github.event_name != 'pull_request'
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+        with:
+          image: ${{ steps.build.outputs.image }}
+          tags: ${{ steps.build.outputs.tags }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+
+      - name: Sign image
+        if: github.event_name != 'pull_request'
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+        run: >-
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY
+          --registry-password='${{ secrets.GITHUB_TOKEN }}'
+          --registry-username='${{ github.actor }}'
+          ${{ env.REGISTRY }}/${{ steps.build.outputs.image }}@${{ steps.push.outputs.digest }}


### PR DESCRIPTION
Continuously create new image releases when relevant changes are detected.

Extra: improve security by pinning github actions to their full length commit hash