### PR TITLE
manifests: add subscription-manager to exclude-packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
       REGISTRY: ghcr.io/${{ github.repository_owner }}/bootc
     needs: check-changes
     if: needs.check-changes.outputs.image == 'true'
-    outputs:
-      digest: 
+    permissions:
+      packages: write
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/almalinux-bootc.yaml
+++ b/almalinux-bootc.yaml
@@ -17,6 +17,9 @@ include:
 packages:
   - dnf-yum
 
+exclude-packages:
+  - subscription-manager
+
 postprocess:
   - |
     #!/usr/bin/env bash


### PR DESCRIPTION
Subscription manager gets pulled in by toolbox, which is not something we want.

Fix permissions needed to publish images to ghcr.io