### PR TITLE
manifests: use add-files instead of post-processes to add files to base image

### DIFF
--- a/almalinux-bootc.yaml
+++ b/almalinux-bootc.yaml
@@ -20,88 +20,12 @@ packages:
 exclude-packages:
   - subscription-manager
 
-postprocess:
-  - |
-    #!/usr/bin/env bash
-    set -eo pipefail
-    cat << 'EOF' > /usr/lib/bootc/install/10-defaults.toml
-    [install.filesystem.root]
-    type = "xfs"
-    EOF
-
-  - |
-    #!/usr/bin/env bash
-    set -eo pipefail
-    mkdir -p /etc/pki/cosign
-    cat << 'EOF' > /etc/pki/cosign/bootc.pub
-    -----BEGIN PUBLIC KEY-----
-    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1lKjx6kge0FRX0Q3AjSROFMfpA2v
-    pUA9ujQGkOwccFYiIdLm29l7GVsq7PwM4nwfRWS4lPRnxqZMtSRnxywlGg==
-    -----END PUBLIC KEY-----
-    EOF
-
-  - |
-    #!/usr/bin/env bash
-    set -eo pipefail
-    cat << 'EOF' > /etc/containers/policy.json
-    {
-        "default": [
-            {
-                "type": "reject"
-            }
-        ],
-        "transports": {
-            "docker": {
-                "ghcr.io/karelvanhecke/bootc": [
-                    {
-                        "type": "sigstoreSigned",
-                        "keyPath": "/etc/pki/cosign/bootc.pub",
-                        "signedIdentity": {
-                            "type": "matchRepository"
-                        }
-                    }
-                ],
-                "registry.access.redhat.com": [
-                    {
-                        "type": "signedBy",
-                        "keyType": "GPGKeys",
-                        "keyPaths": [
-                          "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
-                          "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta"
-                        ]
-                    }
-                ],
-                "registry.redhat.io": [
-                    {
-                        "type": "signedBy",
-                        "keyType": "GPGKeys",
-                        "keyPaths": [
-                          "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
-                          "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta"
-                        ]
-                    }
-                ],
-                "": [
-                    {
-                        "type": "insecureAcceptAnything"
-                    }
-                ]
-            },
-            "docker-daemon": {
-                "": [
-                    {
-                        "type": "insecureAcceptAnything"
-                    }
-                ]
-            }
-        }
-    }
-    EOF
-
-  - |
-    #!/usr/bin/env bash
-    set -eo pipefail
-    cat << 'EOF' > /etc/containers/registries.d/default.yaml
-    default-docker:
-      use-sigstore-attachments: true
-    EOF
+add-files:
+  - - bootc-install.toml
+    - /usr/lib/bootc/install/10-defaults.toml
+  - - cosign.pub
+    - /etc/pki/cosign/bootc.pub
+  - - containers-policy.json
+    - /etc/containers/policy.json
+  - - registries-default.yaml
+    - /etc/containers/registries.d/default.yaml

--- a/bootc-install.toml
+++ b/bootc-install.toml
@@ -1,0 +1,4 @@
+[install.filesystem.root]
+type = "xfs"
+[install]
+kargs = ["console=tty0", "console=ttyS0,115200n8"]

--- a/containers-policy.json
+++ b/containers-policy.json
@@ -1,0 +1,52 @@
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ],
+    "transports": {
+        "docker": {
+            "ghcr.io/karelvanhecke/bootc": [
+                {
+                    "type": "sigstoreSigned",
+                    "keyPath": "/etc/pki/cosign/bootc.pub",
+                    "signedIdentity": {
+                        "type": "matchRepository"
+                    }
+                }
+            ],
+            "registry.access.redhat.com": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPaths": [
+                        "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+                        "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta"
+                    ]
+                }
+            ],
+            "registry.redhat.io": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPaths": [
+                        "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+                        "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta"
+                    ]
+                }
+            ],
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "docker-daemon": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        }
+    }
+}

--- a/registries-default.yaml
+++ b/registries-default.yaml
@@ -1,0 +1,2 @@
+default-docker:
+  use-sigstore-attachments: true


### PR DESCRIPTION
files:
* bootc-install.toml
* cosign.pub (already existed)
* containers-policy.json
* registries-default.yaml

extra: kargs have been added to dedfault bootc install config, even though they don't seem to get picked up during installation