### PR TITLE
manifests: improve structure of container trust configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,11 @@ jobs:
           filters: |
             image:
               - 'fedora-bootc'
-              - 'almalinux-bootc*'
+              - '*.json'
+              - '*.yaml'
+              - '*.toml'
               - 'Dockerfile'
               - 'cosign.pub'
-              - 'containers-policy.json'
-              - 'registries-default.yaml'
-              - 'bootc-install.toml'
 
   build-push:
     name: Build base image

--- a/almalinux-bootc.yaml
+++ b/almalinux-bootc.yaml
@@ -24,8 +24,8 @@ add-files:
   - - bootc-install.toml
     - /usr/lib/bootc/install/10-defaults.toml
   - - cosign.pub
-    - /etc/pki/cosign/bootc.pub
+    - /etc/pki/containers/ghcr.io-karelvanhecke-bootc.pub
   - - containers-policy.json
     - /etc/containers/policy.json
-  - - registries-default.yaml
-    - /etc/containers/registries.d/default.yaml
+  - - containers-registry.yaml
+    - /etc/containers/registries.d/ghcr.io-karelvanhecke-bootc.yaml

--- a/containers-policy.json
+++ b/containers-policy.json
@@ -9,7 +9,7 @@
             "ghcr.io/karelvanhecke/bootc": [
                 {
                     "type": "sigstoreSigned",
-                    "keyPath": "/etc/pki/cosign/bootc.pub",
+                    "keyPath": "/etc/pki/containers/ghcr.io-karelvanhecke-bootc.pub",
                     "signedIdentity": {
                         "type": "matchRepository"
                     }

--- a/containers-registry.yaml
+++ b/containers-registry.yaml
@@ -1,0 +1,3 @@
+docker:
+  ghcr.io/karelvanhecke/bootc:
+    use-sigstore-attachments: true

--- a/registries-default.yaml
+++ b/registries-default.yaml
@@ -1,2 +1,0 @@
-default-docker:
-  use-sigstore-attachments: true


### PR DESCRIPTION
containers registry config: do not modify default, only apply 'use-sigstore-attachments: true' to ghcr.io/karelvanhecke/bootc namespace

cosign public key: move cosign.pub into /etc/pki/containers with a more descriptive name

containers policy.json: update cosign pubkey path