### PR TITLE
release: change versioning to <version id>.<unix timestamp>

### DIFF
--- a/.github/workflows/continuous-release.yml
+++ b/.github/workflows/continuous-release.yml
@@ -24,8 +24,6 @@ jobs:
   build-publish:
     uses: ./.github/workflows/release.yml
     secrets: inherit
-    with:
-      tag-suffixes: "${{ github.sha }} ${{ github.ref_name }}"
     needs: check-changes
     if: ${{ needs.check-changes.outputs.image == 'true' }}
     permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,8 @@ jobs:
             --security-opt=label=disable
             --cap-add=all
             --device /dev/fuse
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Export image as oci archive
         id: export

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,6 @@ on:
         type: string
         required: false
         default: ghcr.io/${{ github.repository_owner }}/bootc
-      tag-suffixes:
-        description: Suffixes to append to the release version tags
-        type: string
-        required: true
 
 jobs:
   build-publish:
@@ -34,15 +30,15 @@ jobs:
         id: tags
         run: |
           #!/bin/bash
-
           set -xeo pipefail
-          releasever=$(yq '.releasever' 'almalinux-bootc.yaml')
-          tags=$releasever
 
-          for suffix in ${{ inputs.tag-suffixes }}
-          do 
-            tags+=" ${releasever}-${suffix}"
-          done
+          versionfile=almalinux-bootc-version.yaml
+
+          releasever=$(yq '.releasever' ${versionfile})
+          version=${releasever}.$(date +%s)
+          yq -i ".add-commit-metadata.version = \"${version}\"" ${versionfile}
+          tags="${releasever%%.*} $releasever $version"
+
           echo "tags=$tags" >> "$GITHUB_OUTPUT"
 
       - name: Build image
@@ -58,6 +54,8 @@ jobs:
             --security-opt=label=disable
             --cap-add=all
             --device /dev/fuse
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Push image to ghcr.io
         id: push

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -11,7 +11,6 @@ jobs:
     if: ${{ github.event_name != 'push' }}
     outputs:
       available: ${{ steps.updates.outputs.available }}
-      timestamp: ${{ steps.updates.outputs.timestamp }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
@@ -34,13 +33,10 @@ jobs:
           else
             echo "available='false'" >> "$GITHUB_OUTPUT"
           fi
-          echo "timestamp=$(date +%s)" >> "$GITHUB_OUTPUT"
 
   build-publish:
     uses: ./.github/workflows/release.yml
     secrets: inherit
-    with:
-      tag-suffixes: ${{ needs.check-updates.outputs.timestamp }}
     needs: check-updates
     if: ${{ needs.check-updates.outputs.available == 'true' }}
     permissions:

--- a/almalinux-bootc-config.json
+++ b/almalinux-bootc-config.json
@@ -3,7 +3,7 @@
         "containers.bootc": "1",
         "bootc.diskimage-builder": "quay.io/centos-bootc/bootc-image-builder",
         "redhat.id": "almalinux",
-        "redhat.version-id": "9",
+        "redhat.version-id": "9.4",
         "org.opencontainers.image.source": "https://github.com/karelvanhecke/almalinux-bootc",
         "org.opencontainers.image.description": "AlmaLinux bootc base image",
         "org.opencontainers.image.licenses": "MIT"

--- a/almalinux-bootc-version.yaml
+++ b/almalinux-bootc-version.yaml
@@ -1,0 +1,3 @@
+releasever: "9.4"
+add-commit-metadata:
+  version: ${releasever}.dev

--- a/almalinux-bootc.yaml
+++ b/almalinux-bootc.yaml
@@ -1,4 +1,3 @@
-releasever: 9
 variables:
   distro: "almalinux"
 
@@ -13,6 +12,7 @@ metadata:
 include:
   - fedora-bootc/tier-1/manifest.yaml
   - fedora-bootc/tier-1/kernel.yaml
+  - almalinux-bootc-version.yaml
 
 packages:
   - dnf-yum
@@ -39,4 +39,12 @@ postprocess:
     #!/usr/bin/env bash
     set -xeo pipefail
 
-    sed -i 's,image = "registry.access.redhat.com/ubi9/toolbox:latest",image = "quay.io/toolbx-images/almalinux-toolbox:9",' /etc/containers/toolbox.conf
+    . /etc/os-release
+    sed -i "s,image = \"registry.access.redhat.com/ubi${VERSION_ID%%.*}/toolbox:latest\",image = \"quay.io/toolbx-images/almalinux-toolbox:${VERSION_ID%%.*}\"," /etc/containers/toolbox.conf
+
+  - |
+    #!/usr/bin/env bash
+    set -xeo pipefail
+
+    . /etc/os-release
+    echo $VERSION_ID > /etc/dnf/vars/releasever


### PR DESCRIPTION
Changes:
  * remove version specific data from almalinux-bootc.yaml manifest
  * change redhat-id in almalinux-bootc-config.json to match releasever
  * setup almalinux-bootc-version.yaml file, this allows injecting the version into the image
  * add revision label in container images build in ci