### PR TITLE
ci: SBOM generation and attestation

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-push:
-    name: Build and push base image
+    name: Build and push
     permissions:
       packages: write
       security-events: write
@@ -83,11 +83,32 @@ jobs:
       - name: Start podman daemon
         run: systemctl --user start podman.socket
 
-      - name: Scan image with Grype
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e8d2a6937ecead383dfe75190d104edd1f9c5751 # v0.16.0
+        with:
+          syft-version: v1.5.0
+          image: podman:${{ steps.push.outputs.registry-path }}@${{ steps.push.outputs.digest }}
+          upload-artifact: false
+          upload-release-assets: false
+          format: json
+          output-file: ${{ inputs.image }}-${{ inputs.version }}.syft.json
+
+      - name: Create SBOM attestation
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+        run: >-
+          cosign attest --yes --key env://COSIGN_PRIVATE_KEY
+          --registry-password='${{ secrets.GITHUB_TOKEN }}'
+          --registry-username='${{ github.actor }}'
+          --predicate='${{ inputs.image }}-${{ inputs.version }}.syft.json'
+          ${{ inputs.registry }}/${{ steps.build.outputs.image }}@${{ steps.push.outputs.digest }}
+
+      - name: Scan SBOM with Grype
         uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a # v3.6.4
         id: scan
         with:
-          image: podman:${{ steps.push.outputs.registry-path }}@${{ steps.push.outputs.digest }}
+          sbom: ${{ inputs.image }}-${{ inputs.version }}.syft.json
           fail-build: false
           output-format: sarif
           only-fixed: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,17 @@ jobs:
 
           releasever=$(yq '.releasever' almalinux-bootc-version.yaml)
           echo "version=${releasever}+$GITHUB_SHA" >> "$GITHUB_OUTPUT"
-          tags="$GITHUB_REF_NAME $GITHUB_SHA"
+          tags="$GITHUB_SHA $GITHUB_REF_NAME v$releasever"
+
+          if [[ $GITHUB_REF_NAME == "main" ]]
+          then
+            tags+=" v${releasever%%.*}"
+          fi
+
           echo "tags=$tags" >> "$GITHUB_OUTPUT"
 
-  build-push:
-    name: Build and push CI image
+  ci-image:
+    name: CI image
     uses: ./.github/workflows/build-push.yml
     with:
       image: almalinux-ci

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,9 @@ on:
       - main
       - v[0-9]+
 
+env:
+  ARTIFACT_NAME_PREFIX: almalinux-pr-${{ github.event.pull_request.number }}
+
 jobs:
   check-changes:
     name: Check changes since last commit
@@ -37,11 +40,32 @@ jobs:
         with:
           submodules: 'true'
 
+      - name: Validate release branch version
+        if: ${{ github.base_ref != 'main' }}
+        run: |
+          #!/bin/bash
+          set -xeo pipefail
+
+          releasever=$(yq '.releasever' almalinux-bootc-version.yaml)
+          if [[ ${GITHUB_BASE_REF#v*} != ${releasever%%.*} ]]
+          then
+            echo "Release branch should match major version in manifest"
+            exit 1
+          fi
+
+      - name: Inject ostree version
+        run: |
+          #!/bin/bash
+          set -xeo pipefail
+
+          releasever=$(yq '.releasever' almalinux-bootc-version.yaml)
+          yq -i ".add-commit-metadata.version = \"${releasever}+$GITHUB_SHA\"" almalinux-bootc-version.yaml
+
       - name: Build image
         id: build
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
-          image: almalinux-pr
+          image: ${{ env.ARTIFACT_NAME_PREFIX }}
           tags: ${{ github.sha }}
           containerfiles: |
             Dockerfile
@@ -73,25 +97,43 @@ jobs:
           retention-days: 1
           compression-level: 0 # oci-archive is already compressed
 
-  scan:
-    name: Vulnerability scan
+  sbom:
+    name: Generate SBOM
     runs-on: ubuntu-24.04
     needs: build
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-
       - name: Download oci archive
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ${{ needs.build.outputs.oci-archive }}
+      
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e8d2a6937ecead383dfe75190d104edd1f9c5751 # v0.16.0
+        with:
+          syft-version: v1.5.0
+          image: oci-archive:${{ needs.build.outputs.oci-archive }}
+          artifact-name: ${{ env.ARTIFACT_NAME_PREFIX }}-${{ github.sha }}.syft.json
+          format: json
+          upload-artifact: true
+          upload-artifact-retention: 1
+          upload-release-assets: false
 
-      - name: Scan image with Grype
+  scan:
+    name: Vulnerability scan
+    runs-on: ubuntu-24.04
+    needs: sbom
+    steps:
+      - name: Download SBOM
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: ${{ env.ARTIFACT_NAME_PREFIX }}-${{ github.sha }}.syft.json
+
+      - name: Scan SBOM with Grype
         uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a # v3.6.4
         id: scan
         with:
-          image: oci-archive:${{ needs.build.outputs.oci-archive }}
-          fail-build: true
+          sbom: ${{ env.ARTIFACT_NAME_PREFIX }}-${{ github.sha }}.syft.json
+          fail-build: false
           output-format: table
           only-fixed: true
           grype-version: v0.78.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,11 @@ jobs:
 
           releasever=$(yq '.releasever' almalinux-bootc-version.yaml)
           echo "version=${GITHUB_REF_NAME#v*}" >> "$GITHUB_OUTPUT"
-          tags="${GITHUB_REF_NAME%%.*} ${GITHUB_REF_NAME%.*} ${GITHUB_REF_NAME}"
+          tags="${GITHUB_REF_NAME} ${GITHUB_REF_NAME%.*} ${GITHUB_REF_NAME%%.*}"
           echo "tags=$tags" >> "$GITHUB_OUTPUT"
 
-  build-push:
-    name: Build and push release image
+  release-image:
+    name: Release image
     uses: ./.github/workflows/build-push.yml
     with:
       image: almalinux
@@ -68,3 +68,4 @@ jobs:
           tag_name: ${{ github.ref }}
           generate_release_notes: true
           draft: true
+          files: cosign.pub


### PR DESCRIPTION
* Enable SBOM generation during the PR workflow.
* Enable SBOM generation and attestation during the 'Build and push' workflow(Used by release and CI workflows).
* Use SBOM as input for the Grype vulnerability scanner

Notes:
* Scheduled scan will be updated in another PR and rebased onto main after the next release.
* SBOM generation is handled in a different job during the PR workflow. The SBOM is only meant to be used as input for other tools like Grype during this workflow and doesn't provide any other value.
