### PR TITLE
lockfile: apply updates 2024/07/21 (contains CVE fixes)

### DIFF
--- a/almalinux-bootc-lock.amd64.json
+++ b/almalinux-bootc-lock.amd64.json
@@ -974,29 +974,29 @@
       }
     },
     "kernel": {
-      "evra": "5.14.0-427.24.1.el9_4.x86_64",
-      "digest": "sha256:5ef04f28571c79da8adfee3661b81813d1b68ea0bee7f86814231b395e995ef7",
+      "evra": "5.14.0-427.26.1.el9_4.x86_64",
+      "digest": "sha256:4f9cb222879bc64c06837a0a0a98e631128692f737ef2b67b5a74d8305040495",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "5.14.0-427.24.1.el9_4.x86_64",
-      "digest": "sha256:a9f4012d82fc2a9493b83399315658cdbf99914152e14b1d0dfb7170504c2e36",
+      "evra": "5.14.0-427.26.1.el9_4.x86_64",
+      "digest": "sha256:40847814679d88f6c6eaabd3101c0ccd070193b40b2482ce29314d2a8e76e2b2",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "5.14.0-427.24.1.el9_4.x86_64",
-      "digest": "sha256:ca08de6edf6ece2ba953f78c13f06e558e8e26f4f837e7ecdc0aa522a6fbe13a",
+      "evra": "5.14.0-427.26.1.el9_4.x86_64",
+      "digest": "sha256:956cbcf39033c9749539b2703edc6fb3a6edc427ca1185213f72eab95dad97ac",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "5.14.0-427.24.1.el9_4.x86_64",
-      "digest": "sha256:4d173f4bc15f86fb99e1577b3be314f921ee0c5383d79782d037f21fcf0e60e2",
+      "evra": "5.14.0-427.26.1.el9_4.x86_64",
+      "digest": "sha256:c27ac9a66a0c0a008ca891037497307cf59b0057e60ad0f963c9937e51d7b40b",
       "metadata": {
         "sourcerpm": "kernel"
       }
@@ -1443,8 +1443,8 @@
       }
     },
     "libndp": {
-      "evra": "1.8-4.el9.x86_64",
-      "digest": "sha256:8bccdbe7262ddacd98ba5dbd12fcab2bcccefcf6f27ffcd7e265a35bd4d38d68",
+      "evra": "1.8-6.el9_4.alma.1.x86_64",
+      "digest": "sha256:e64914236c532fbe81a23bd1593c81c6d997f7c23d714281255b1f1fa3cc887f",
       "metadata": {
         "sourcerpm": "libndp"
       }
@@ -2963,13 +2963,13 @@
     }
   },
   "metadata": {
-    "generated": "2024-07-12T00:00:00Z",
+    "generated": "2024-07-21T00:00:00Z",
     "rpmmd_repos": {
       "appstream": {
-        "generated": "2024-07-12T07:54:11Z"
+        "generated": "2024-07-19T11:10:33Z"
       },
       "baseos": {
-        "generated": "2024-07-12T07:54:44Z"
+        "generated": "2024-07-19T11:11:16Z"
       }
     }
   }


### PR DESCRIPTION
libndp:
  * CVE-2024-5564

kernel:
  * CVE-2024-36904
  * CVE-2024-36886
  * CVE-2024-27397
  * CVE-2024-38663
  * CVE-2024-38593
  * CVE-2024-38586
  * CVE-2024-38543
  * CVE-2024-36957
  * CVE-2024-36270
  * CVE-2024-35958
  * CVE-2024-27435
  * CVE-2024-26858
  * CVE-2024-26783
  * CVE-2024-52638
  * CVE-2024-48627
  * CVE-2024-47596
  * CVE-2024-47548